### PR TITLE
Add store_test_results upload and store test results to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   docker-executor:
     docker:
-      - image: cloudcomputing321/ninja-image:latest
+      - image: cloudcomputing321/shadowdash:latest
 
 jobs:
   build:
@@ -35,7 +35,9 @@ jobs:
           name: Run Tests In Parallelism with CTests
           command: |
             cd build-cmake
-            ctest --verbose -j4
+            ctest --output-junit results.xml --verbose -j4
+      - store_test_results:
+          path: build-cmake
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a base image
-FROM cimg/base:stable
+FROM cimg/base:current
 
 USER root
 


### PR DESCRIPTION
1. Use a new Docker image with `current` base image for newer cmake/ctest version
2. Add `store-test-results` to config to integrate with circleCI